### PR TITLE
Prevent BasicAuth when username/api_token are unset

### DIFF
--- a/jenkins.py
+++ b/jenkins.py
@@ -161,7 +161,7 @@ def get_auth_args(module_config):
 
     if key_file and cert_file:
         args["cert"] = (cert_file, key_file)
-    else:
+    elif module_config['username'] and module_config['api_token']:
         args["auth"] = HTTPBasicAuth(module_config['username'], module_config['api_token'])
 
     if ca_certs:

--- a/test_jenkins.py
+++ b/test_jenkins.py
@@ -133,3 +133,9 @@ def test_boolean_config():
 @mock.patch('jenkins.get_response', mock_api_call)
 def test_read():
     jenkins.read_metrics(jenkins.read_config(mock_config))
+
+
+def test_get_auth_args():
+    module_config = jenkins.read_config(mock_config)
+    auth_args = jenkins.get_auth_args(module_config)
+    assert 'auth' not in auth_args


### PR DESCRIPTION
Fix issue where "Authorization" header is set, even if "username" and
"api_token" are not set by the user.

Observed case where if username and api_token are not set,
`HTTPBasicAuth` is still invoked, setting header - `Authorization: Basic Og==` ("Og==" is base64 encoding of ":")

So only invoke `HTTPBasicAuth` when username AND api_token are set.