### PR TITLE
Add new parameter to exclude job metrics retrieved from /api/json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.pyc
 .cache
 __pycache__
+venv
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Optional configurations keys include:
 * IncludeMetric - Advanced Metrics from the `/metrics/<MetricsKey>/metrics` endpoint can be included individually
 * ExcludeMetric - Advanced Metrics from the `/metrics/<MetricsKey>/metrics` endpoint can be excluded individually
 * Dimension - Add extra dimensions to your metrics
+* ExcludeJobMetrics - Flag to specify whether to collect extra job metrics from the Jenkins `/json/api`.
 
 ### SSL/TLS
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Optional configurations keys include:
 * IncludeMetric - Advanced Metrics from the `/metrics/<MetricsKey>/metrics` endpoint can be included individually
 * ExcludeMetric - Advanced Metrics from the `/metrics/<MetricsKey>/metrics` endpoint can be excluded individually
 * Dimension - Add extra dimensions to your metrics
-* ExcludeJobMetrics - Flag to specify whether to collect extra job metrics from the Jenkins `/json/api`.
+* ExcludeJobMetrics - Flag to specify whether to exclude calls to `/json/api` for all jobs and builds.
 
 ### SSL/TLS
 

--- a/jenkins.py
+++ b/jenkins.py
@@ -543,7 +543,8 @@ def read_metrics(module_config):
             else:
                 last_timestamp = int(time.time() * 1000) - (60 * 1000)
                 module_config["jobs_last_timestamp"][job["name"]] = last_timestamp
-            read_and_post_job_metrics(module_config, job["url"], job["name"], last_timestamp)
+            job_url = module_config["base_url"][:-1] + urllib.parse.urlparse(job["url"]).path
+            read_and_post_job_metrics(module_config, job_url, job["name"], last_timestamp)
 
 
 def init():

--- a/jenkins.py
+++ b/jenkins.py
@@ -185,6 +185,7 @@ def read_config(conf):
         "http_timeout": DEFAULT_API_TIMEOUT,
         "jobs_last_timestamp": {},
         "ssl_keys": {"enabled": False, "ssl_cert_validation": True},
+        "exclude_job_metrics": False,
     }
 
     interval = None
@@ -217,6 +218,8 @@ def read_config(conf):
             module_config["include_optional_metrics"].add(val.values[0])
         elif val.key == "ExcludeMetric" and val.values[0] and val.values[0] not in NODE_METRICS:
             module_config["exclude_optional_metrics"].add(val.values[0])
+        elif val.key == "ExcludeJobMetrics" and val.values[0]:
+            module_config["exclude_job_metrics"] = str_to_bool(val.values[0])
         elif val.key == "ssl_enabled" and val.values[0]:
             module_config["ssl_keys"]["enabled"] = str_to_bool(val.values[0])
         elif val.key == "ssl_keyfile" and val.values[0]:
@@ -523,6 +526,9 @@ def read_metrics(module_config):
 
     if resp_obj is not None:
         parse_and_post_healthcheck(module_config, resp_obj)
+
+    if module_config["exclude_job_metrics"]:
+        return
 
     resp_obj = get_response(module_config["base_url"], "job_tree", module_config)
 

--- a/test_jenkins.py
+++ b/test_jenkins.py
@@ -77,6 +77,35 @@ mock_config_enhanced_metrics_off.children = [
     ConfigOption('Testing', ('True',))
 ]
 
+mock_read_and_post_job_metrics = mock.Mock()
+mock_config_job_metrics_off = mock.Mock()
+mock_config_job_metrics_off.children = [
+    ConfigOption('Host', ('localhost',)),
+    ConfigOption('Port', ('22379',)),
+    ConfigOption('MetricsKey', ('6Z95HwGBHOj4uBOlsakGR91dxbFenpfz_g2wdBlUAh0-ocmK-CvdHLSvE1LGRdmg',)),
+    ConfigOption('Interval', ('10',)),
+    ConfigOption('ExcludeJobMetrics', ('True',)),
+    ConfigOption('Testing', ('True',))
+]
+
+
+@mock.patch('jenkins.get_response', mock_api_call)
+@mock.patch('jenkins.read_and_post_job_metrics', mock_read_and_post_job_metrics)
+def test_job_url():
+    module_config = jenkins.read_config(mock_config_enhanced_metrics_off)
+    jenkins.read_metrics(module_config)
+    args = mock_read_and_post_job_metrics.call_args.args
+    assert args[1].startswith(module_config["base_url"])
+
+
+@mock.patch('jenkins.get_response', mock_api_call)
+@mock.patch('jenkins.read_and_post_job_metrics', mock_read_and_post_job_metrics)
+def test_job_metrics_off():
+    mock_read_and_post_job_metrics.reset_mock()
+    module_config = jenkins.read_config(mock_config_job_metrics_off)
+    jenkins.read_metrics(module_config)
+    mock_read_and_post_job_metrics.assert_not_called()
+
 
 @mock.patch('jenkins.get_response', mock_api_call)
 def test_optional_metrics_on():
@@ -128,6 +157,7 @@ def test_boolean_config():
     assert module_config['metrics_key'] == '6Z95HwGBHOj4uBOlsakGR91dxbFenpfz_g2wdBlUAh0-ocmK-CvdHLSvE1LGRdmg'
     assert module_config['base_url'] == 'http://localhost:2379/'
     assert module_config['enhanced_metrics'] == False
+    assert module_config['exclude_job_metrics'] == False
 
 
 @mock.patch('jenkins.get_response', mock_api_call)


### PR DESCRIPTION
On some servers with a large number of jobs, retrieving the data for every job and build via `/api/json` will not scale.

A new parameter `ExcludeJobMetrics` will prevent these calls from being made when `True` (default `False`).

This PR also includes a bug fix whereby the calls to `/api/json` to collect job metrics are not using the collectd config for `base_url`.