### PR TITLE
Fix filtering out string metric values with Python 2

### DIFF
--- a/jenkins.py
+++ b/jenkins.py
@@ -5,6 +5,7 @@ import collections
 import json
 import pprint
 import time
+import sys
 
 import requests
 import urllib3
@@ -14,6 +15,10 @@ from six.moves import urllib
 from six.moves.urllib.parse import quote as urllib_quote
 
 import collectd
+
+# unicode does not exist in python 3
+if sys.version_info[0] >= 3:
+    unicode = str
 
 # Prevents spamming when not validating certificates.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -419,6 +424,7 @@ def parse_and_post_metrics(module_config, resp):
             if (
                 metric in module_config["exclude_optional_metrics"]
                 or type(resp[metric]["value"]) is str
+                or type(resp[metric]["value"]) is unicode
                 or type(resp[metric]["value"]) is bytes
                 or type(resp[metric]["value"]) is list
             ):
@@ -430,6 +436,7 @@ def parse_and_post_metrics(module_config, resp):
         for metric in module_config["include_optional_metrics"]:
             if metric in resp and not (
                 type(resp[metric]["value"]) is str
+                or type(resp[metric]["value"]) is unicode
                 or type(resp[metric]["value"]) is bytes
                 or type(resp[metric]["value"]) is list
             ):

--- a/sample_responses.py
+++ b/sample_responses.py
@@ -156,6 +156,9 @@ metrics = {
 		"jenkins.queue.stuck.value": {
 			"value": 0
 		},
+		"jenkins.versions.core": {
+			"value": "2.277.4"
+		},
 		"system.cpu.load": {
 			"value": 1.37548828125
 		},


### PR DESCRIPTION
This prevents dispatching string valued metrics when using Python 2 (String values are not accepted by collectd).

I'm not sure aliasing `unicode` to `str` in the Python 3 case is the best way to fix this. Maybe importing the `six` compatibility library would be preferred?