### PR TITLE
Fix job URL when Jenkins URL is set and address URL encoding when job URLs are already quoted

### DIFF
--- a/integration-test/Dockerfile.jenkins
+++ b/integration-test/Dockerfile.jenkins
@@ -1,5 +1,6 @@
 FROM jenkins/jenkins:%%%VER%%%
 COPY integration-test/metrics.groovy /usr/share/jenkins/ref/init.groovy.d/metrics.groovy
+ENV CURL_OPTIONS -ksSfL
 RUN /usr/local/bin/install-plugins.sh docker-slaves metrics cloudbees-folder
 
 ARG PORT

--- a/sample_responses.py
+++ b/sample_responses.py
@@ -40,6 +40,12 @@ job_tree = {
       "name": "Data1",
       "url": "http://localhost:8080/job/testjob/",
       "color": "blue"
+    },
+    {
+      "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+      "name": "pipeline ` job",
+      "url": "http://127.0.0.1:8080/jenkins/job/pipeline%20%60%20%20job/",
+      "color": "aborted"
     }
   ]
 }


### PR DESCRIPTION
When a Jenkins instance is only configured with `--prefix` and the monitor setting `path` is set, the `path` value is appended to the job URL correctly, but when `Jenkins URL` is configured in addition to `--prefix` the Job URL will already contain the path (assuming prefix and Jenkins URL path are identical).

This PR checks the start of the Job path to see if the monitor `path` already exists or needs to be added.

While validating this fix, I have noticed that the job URLs fetched from Jenkins are already encoded and the `_api_call` was failing as it does a second `quote` (changing the correct path)
I assume this is a recent change from Jenkins, to keep it backward compatible, we are now unquoting the job URL before calling  `_api_call`

cc: @keitwb @dtcimbal 
Signed-off-by: Dani Louca <dlouca@splunk.com>